### PR TITLE
SqlServerBatchRunner handling of null parameters

### DIFF
--- a/Source/EntityFramework.Extended/Batch/SqlServerBatchRunner.cs
+++ b/Source/EntityFramework.Extended/Batch/SqlServerBatchRunner.cs
@@ -268,9 +268,12 @@ namespace EntityFramework.Batch
 
                             var parameter = updateCommand.CreateParameter();
                             parameter.ParameterName = parameterName;
-                            parameter.Value = objectParameter.Value;
+                            
+                            // set the parameter value, ensure null values are replaced with DBNull.Value
+                            parameter.Value = objectParameter.Value ?? (object)DBNull.Value;
+                            
                             updateCommand.Parameters.Add(parameter);
-
+                            
                             value = value.Replace(objectParameter.Name, parameterName);
                         }
                         sqlBuilder.AppendFormat("[{0}] = {1}", columnName, value);
@@ -365,8 +368,10 @@ namespace EntityFramework.Batch
             {
                 var parameter = command.CreateParameter();
                 parameter.ParameterName = objectParameter.Name;
-                parameter.Value = objectParameter.Value;
 
+                // set the parameter value, ensure null values are replaced with DBNull.Value
+                parameter.Value = objectParameter.Value ?? (object)DBNull.Value;
+                
                 command.Parameters.Add(parameter);
             }
 

--- a/Source/Samples/net45/Tracker.SqlServer.Test/BatchDbContext.cs
+++ b/Source/Samples/net45/Tracker.SqlServer.Test/BatchDbContext.cs
@@ -41,10 +41,10 @@ namespace Tracker.SqlServer.Test
             // This test verifies that the delete is processed correctly when the where expression uses a parameter with a null parameter
             var db = new TrackerContext();
             string emailDomain = "@test.com";
-            string nullComparisonString = null;
+            string optionalComparisonString = null;
 
             int count = db.Users
-                .Delete(u => u.EmailAddress.EndsWith(emailDomain) && u.AvatarType == nullComparisonString);
+                .Delete(u => u.EmailAddress.EndsWith(emailDomain) && (string.IsNullOrEmpty(optionalComparisonString) || u.AvatarType == optionalComparisonString));
         }
         
         [TestMethod]
@@ -52,11 +52,11 @@ namespace Tracker.SqlServer.Test
         {
             var db = new TrackerContext();
             string emailDomain = "@test.com";
-            string nullComparisonString = null;
+            string optionalComparisonString = null;
 
             // This test verifies that the delete is processed correctly when the where expression uses a parameter with a null parameter
             int count = db.Users
-                .Where(u => u.EmailAddress.EndsWith(emailDomain) && u.AvatarType == nullComparisonString)
+                .Where(u => u.EmailAddress.EndsWith(emailDomain) && (string.IsNullOrEmpty(optionalComparisonString) || u.AvatarType == optionalComparisonString))
                 .Delete();
         }
 
@@ -76,10 +76,10 @@ namespace Tracker.SqlServer.Test
             // This test verifies that the update is interpreted correctly when the where expression uses a parameter with a null parameter
             var db = new TrackerContext();
             string emailDomain = "@test.com";
-            string nullComparisonString = null;
+            string optionalComparisonString = null;
 
             int count = db.Users.Update(
-                u => u.EmailAddress.EndsWith(emailDomain) && u.AvatarType == nullComparisonString,
+                u => u.EmailAddress.EndsWith(emailDomain) && (string.IsNullOrEmpty(optionalComparisonString) || u.AvatarType == optionalComparisonString),
                 u => new User { IsApproved = false, LastActivityDate = DateTime.Now });
         }
 

--- a/Source/Samples/net45/Tracker.SqlServer.Test/BatchDbContext.cs
+++ b/Source/Samples/net45/Tracker.SqlServer.Test/BatchDbContext.cs
@@ -21,6 +21,7 @@ namespace Tracker.SqlServer.Test
             int count = db.Users
                 .Delete(u => u.EmailAddress.EndsWith(emailDomain));
         }
+
         [TestMethod]
         public void DeleteWhere()
         {
@@ -35,12 +36,50 @@ namespace Tracker.SqlServer.Test
         }
 
         [TestMethod]
+        public void DeleteWithExpressionContainingNullParameter()
+        {
+            // This test verifies that the delete is processed correctly when the where expression uses a parameter with a null parameter
+            var db = new TrackerContext();
+            string emailDomain = "@test.com";
+            string nullComparisonString = null;
+
+            int count = db.Users
+                .Delete(u => u.EmailAddress.EndsWith(emailDomain) && u.AvatarType == nullComparisonString);
+        }
+        
+        [TestMethod]
+        public void DeleteWhereWithExpressionContainingNullParameter()
+        {
+            var db = new TrackerContext();
+            string emailDomain = "@test.com";
+            string nullComparisonString = null;
+
+            // This test verifies that the delete is processed correctly when the where expression uses a parameter with a null parameter
+            int count = db.Users
+                .Where(u => u.EmailAddress.EndsWith(emailDomain) && u.AvatarType == nullComparisonString)
+                .Delete();
+        }
+
+        [TestMethod]
         public void Update()
         {
             var db = new TrackerContext();
             string emailDomain = "@test.com";
             int count = db.Users.Update(
                 u => u.EmailAddress.EndsWith(emailDomain),
+                u => new User { IsApproved = false, LastActivityDate = DateTime.Now });
+        }
+
+        [TestMethod]
+        public void UpdateWithExpressionContainingNullParameter()
+        {
+            // This test verifies that the update is interpreted correctly when the where expression uses a parameter with a null parameter
+            var db = new TrackerContext();
+            string emailDomain = "@test.com";
+            string nullComparisonString = null;
+
+            int count = db.Users.Update(
+                u => u.EmailAddress.EndsWith(emailDomain) && u.AvatarType == nullComparisonString,
                 u => new User { IsApproved = false, LastActivityDate = DateTime.Now });
         }
 

--- a/Source/Samples/net45/Tracker.SqlServer.Test/BatchObjectContext.cs
+++ b/Source/Samples/net45/Tracker.SqlServer.Test/BatchObjectContext.cs
@@ -27,9 +27,9 @@ namespace Tracker.SqlServer.Test
             // This test verifies that the delete is processed correctly when the where expression uses a parameter with a null parameter
             var db = new TrackerEntities();
             string emailDomain = "@test.com";
-            string nullComparisonString = null;
+            string optionalComparisonString = null;
 
-            int count = db.Users.Delete(u => u.Email.EndsWith(emailDomain) && u.AvatarType == nullComparisonString);
+            int count = db.Users.Delete(u => u.Email.EndsWith(emailDomain) && (string.IsNullOrEmpty(optionalComparisonString) || u.AvatarType == optionalComparisonString));
         }
 
         [TestMethod]
@@ -38,10 +38,10 @@ namespace Tracker.SqlServer.Test
             // This test verifies that the delete is processed correctly when the where expression uses a parameter with a null parameter
             var db = new TrackerEntities();
             string emailDomain = "@test.com";
-            string nullComparisonString = null; 
+            string optionalComparisonString = null; 
             
             int count = db.Users
-                .Where(u => u.AvatarType == nullComparisonString && u.Email.EndsWith(emailDomain))
+                .Where(u => (string.IsNullOrEmpty(optionalComparisonString) || u.AvatarType == optionalComparisonString) && u.Email.EndsWith(emailDomain))
                 .Delete();
         }
 
@@ -61,10 +61,10 @@ namespace Tracker.SqlServer.Test
             // This test verifies that the update is interpreted correctly when the where expression uses a parameter with a null parameter
             var db = new TrackerEntities();
             string emailDomain = "@test.com";
-            string nullComparisonString = null;
+            string optionalComparisonString = null;
 
             int count = db.Users.Update(
-                u => u.Email.EndsWith(emailDomain) && u.AvatarType == nullComparisonString,
+                u => u.Email.EndsWith(emailDomain) && (string.IsNullOrEmpty(optionalComparisonString) || u.AvatarType == optionalComparisonString),
                 u => new User { IsApproved = false, LastActivityDate = DateTime.Now });
         }
     }

--- a/Source/Samples/net45/Tracker.SqlServer.Test/BatchObjectContext.cs
+++ b/Source/Samples/net45/Tracker.SqlServer.Test/BatchObjectContext.cs
@@ -22,12 +22,49 @@ namespace Tracker.SqlServer.Test
         }
 
         [TestMethod]
+        public void DeleteWithExpressionContainingNullParameter()
+        {
+            // This test verifies that the delete is processed correctly when the where expression uses a parameter with a null parameter
+            var db = new TrackerEntities();
+            string emailDomain = "@test.com";
+            string nullComparisonString = null;
+
+            int count = db.Users.Delete(u => u.Email.EndsWith(emailDomain) && u.AvatarType == nullComparisonString);
+        }
+
+        [TestMethod]
+        public void DeleteWhereWithExpressionContainingNullParameter()
+        {
+            // This test verifies that the delete is processed correctly when the where expression uses a parameter with a null parameter
+            var db = new TrackerEntities();
+            string emailDomain = "@test.com";
+            string nullComparisonString = null; 
+            
+            int count = db.Users
+                .Where(u => u.AvatarType == nullComparisonString && u.Email.EndsWith(emailDomain))
+                .Delete();
+        }
+
+        [TestMethod]
         public void Update()
         {
             var db = new TrackerEntities();
             string emailDomain = "@test.com";
             int count = db.Users.Update(
                 u => u.Email.EndsWith(emailDomain),
+                u => new User { IsApproved = false, LastActivityDate = DateTime.Now });
+        }
+
+        [TestMethod]
+        public void UpdateWithExpressionContainingNullParameter()
+        {
+            // This test verifies that the update is interpreted correctly when the where expression uses a parameter with a null parameter
+            var db = new TrackerEntities();
+            string emailDomain = "@test.com";
+            string nullComparisonString = null;
+
+            int count = db.Users.Update(
+                u => u.Email.EndsWith(emailDomain) && u.AvatarType == nullComparisonString,
                 u => new User { IsApproved = false, LastActivityDate = DateTime.Now });
         }
     }


### PR DESCRIPTION
This pull request contains a small change to address an issue I encountered with the SqlServerBatchRunner when dealing with string parameters in expressions. Where a string parameter in the expression has a null value, the SqlServerBatchRunner currently adds Parameters to the ADO.Net Command objects with null values rather than DbNull.Value which causes an exception to be thrown in some cases.

[I have recreated this pull request as the previous one was accidentally created from the wrong branch]

The type of query expression that triggered this problem is of the type:

db.Users.Where(u => u.EmailAddress.EndsWith(emailDomain) && (string.IsNullOrEmpty(optionalComparisonString) || u.AvatarType == optionalComparisonString))
.Delete();

The query can alternatively be rewritten in pieces to avoid this problem... (ie add the filter expression only where the optional parameter is non-null).. however when there are a number of these kinds of parameters it is more convenient to use the form above.

I have added some tests to cover this.