### PR TITLE
Added possibility to inject an IQueryUnwrapper instance.

### DIFF
--- a/Source/EntityFramework.Extended/EntityFramework.Extended.csproj
+++ b/Source/EntityFramework.Extended/EntityFramework.Extended.csproj
@@ -90,6 +90,7 @@
     <Compile Include="Caching\Query\LocalCollectionExpander.cs" />
     <Compile Include="Caching\Query\QueryCache.cs" />
     <Compile Include="Caching\Query\Utility.cs" />
+    <Compile Include="Extensions\IQueryUnwrapper.cs" />
     <Compile Include="Future\IFutureRunner.cs" />
     <Compile Include="Locator.cs" />
     <Compile Include="Container.cs" />

--- a/Source/EntityFramework.Extended/EntityFramework.Extended.net40.csproj
+++ b/Source/EntityFramework.Extended/EntityFramework.Extended.net40.csproj
@@ -90,6 +90,7 @@
     <Compile Include="Caching\Query\LocalCollectionExpander.cs" />
     <Compile Include="Caching\Query\QueryCache.cs" />
     <Compile Include="Caching\Query\Utility.cs" />
+    <Compile Include="Extensions\IQueryUnwrapper.cs" /> 
     <Compile Include="Future\IFutureRunner.cs" />
     <Compile Include="Locator.cs" />
     <Compile Include="Container.cs" />

--- a/Source/EntityFramework.Extended/Extensions/IQueryUnwrapper.cs
+++ b/Source/EntityFramework.Extended/Extensions/IQueryUnwrapper.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EntityFramework.Extensions
+{
+    /// <summary>
+    /// A generic interface for injecting query unwrappers.
+    /// </summary>
+    public interface IQueryUnwrapper
+    {
+        /// <summary>
+        /// Unwrap the given query
+        /// </summary>
+        /// <typeparam name="TEntity">the entity type</typeparam>
+        /// <param name="query">the query to unwrap</param>
+        /// <returns>the unwrapped query</returns>
+        IQueryable<TEntity> Unwrap<TEntity>(IQueryable<TEntity> query)
+            where TEntity : class;
+    }
+}

--- a/Source/EntityFramework.Extended/Extensions/ObjectQueryExtensions.cs
+++ b/Source/EntityFramework.Extended/Extensions/ObjectQueryExtensions.cs
@@ -21,6 +21,12 @@ namespace EntityFramework.Extensions
       /// <returns>The converted ObjectQuery; otherwise null if it can't be converted.</returns>
       public static ObjectQuery<TEntity> ToObjectQuery<TEntity>(this IQueryable<TEntity> query) where TEntity : class
       {
+          var queryUnwrapper = Locator.Current.Resolve<IQueryUnwrapper>();
+          if (queryUnwrapper != null)
+          {
+              query = queryUnwrapper.Unwrap(query);
+          }
+
           // first try direct cast
           var objectQuery = query as ObjectQuery<TEntity>;
           if (objectQuery != null)


### PR DESCRIPTION
This can be used to support custom query types.
We wrote a custom query type enhancing standard DBQueries with support for "enums as strings" and NodaTime types and some other neat extensions.
Unfortunately we could not use EntityFramework.Extended any more - so I wrote this patch for EF.Extended