### PR TITLE
Supports LinqKit expandable queries.

### DIFF
--- a/Source/EntityFramework.Extended/Extensions/ObjectQueryExtensions.cs
+++ b/Source/EntityFramework.Extended/Extensions/ObjectQueryExtensions.cs
@@ -29,6 +29,12 @@ namespace EntityFramework.Extensions
           // next try case to DbQuery
           var dbQuery = query as DbQuery<TEntity>;
           if (dbQuery == null)
+          {
+              // Now check if it's a DbQuery inside of a linqKit ExpandableQuery
+              dynamic linqKitProxy = new DynamicProxy(query, false);
+              dbQuery = linqKitProxy.InnerQuery;
+          }
+          if (dbQuery == null)
               return null;
 
           // access internal property InternalQuery
@@ -61,6 +67,12 @@ namespace EntityFramework.Extensions
 
           // next try case to DbQuery
           var dbQuery = query as DbQuery;
+          if (dbQuery == null)
+          {
+              // Now check if it's a DbQuery inside of a linqKit ExpandableQuery
+              dynamic linqKitProxy = new DynamicProxy(query, false);
+              dbQuery = linqKitProxy.InnerQuery;
+          }
           if (dbQuery == null)
               return null;
 


### PR DESCRIPTION
This has been tested with the Delete() extension method, but should work with anything that calls ObjectQueryExtensions.toObjectQuery since all it does is access the InnerQuery property of the ExpandableQuery.
I'm didn't add any new tests for this, since it would involve making a new (at least build-time) dependency on LinqKit.