### PR TITLE
Change AuditStateEntry's EntityType so that it returns the correct underlying EntityType

### DIFF
--- a/Source/EntityFramework.Extended/Audit/AuditLogger.cs
+++ b/Source/EntityFramework.Extended/Audit/AuditLogger.cs
@@ -164,10 +164,9 @@ namespace EntityFramework.Audit
                 if (!Configuration.IsAuditable(entityType))
                     continue;
 
-                var state = new AuditEntryState(objectStateEntry)
+                var state = new AuditEntryState(ObjectContext, objectStateEntry)
                 {
                     AuditLog = auditLog,
-                    ObjectContext = ObjectContext,
                 };
 
                 if (WriteEntity(state))

--- a/Source/Samples/net45/Tracker.SqlServer.Test/Tracker.SqlServer.Test.csproj
+++ b/Source/Samples/net45/Tracker.SqlServer.Test/Tracker.SqlServer.Test.csproj
@@ -116,6 +116,9 @@
     </None>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Entities that inherit from a base entity are not having their changed properties written to the audit log.
I believe the source of the problem lies with the way EntityType of an entity is being retrieved from the ObjectContext.

For example given the following Code First model:

    public abstract class Vehicle
    {
        public int VehicleID { get; set; }
        public int NumWheels { get; set; }
    }

    public class Car : Vehicle
    {
        public int NumSeats { get; set; }
    }

    public class Truck : Vehicle
    {
        public int MaxLoad { get; set; }
    }

If you try to retrieve the EntityType of Car with the following line of code in `EntityFramework.Audit.AuditEntryState line 23` 
`EntityType = objectStateEntry.EntitySet.ElementType as EntityType;`
The EntityType returned becomes Vehicle and not Car.

Later on in `EntityFramework.Audit.AuditLogger line 227` when you compare the modified properties of Car using `var properties = state.EntityType.Properties` it would **only** give you a VehicleID and NumWheels off of the Vechicle.

This pull request modifies the EntityType retrieval strategy so that it will return the underlying EntityType of an entity that inherits from an abstract base entity which hopefully allows accurate modified properties comparison.
