### PR TITLE
Adding mocking/testing support into the Future Extension Methods

### DIFF
--- a/Source/EntityFramework.Extended/Extensions/FutureExtensions.cs
+++ b/Source/EntityFramework.Extended/Extensions/FutureExtensions.cs
@@ -30,7 +30,13 @@ namespace EntityFramework.Extensions
 
             ObjectQuery<TEntity> sourceQuery = source.ToObjectQuery();
             if (sourceQuery == null)
+            {
+                // Early return for test scenarios, here so it only slows down the error path
+                if (source is IFutureTestQueryable<TEntity>)
+                    return new FutureQuery<TEntity>(source, null);
+
                 throw new ArgumentException("The source query must be of type ObjectQuery or DbQuery.", "source");
+            }
 
             var futureContext = GetFutureContext(sourceQuery);
             var future = new FutureQuery<TEntity>(sourceQuery, futureContext.ExecuteFutureQueries);
@@ -54,7 +60,13 @@ namespace EntityFramework.Extensions
 
             ObjectQuery sourceQuery = source.ToObjectQuery();
             if (sourceQuery == null)
+            {
+                // Early return for test scenarios, here so it only slows down the error path
+                if (source is IFutureTestQueryable)
+                    return new FutureCount(source, null);
+
                 throw new ArgumentException("The source query must be of type ObjectQuery or DbQuery.", "source");
+            }
 
             // create count expression
             var expression = Expression.Call(
@@ -88,7 +100,13 @@ namespace EntityFramework.Extensions
 
             var sourceQuery = source.ToObjectQuery();
             if (sourceQuery == null)
+            {
+                // Early return for test scenarios, here so it only slows down the error path
+                if (source is IFutureTestQueryable<TEntity>)
+                    return new FutureValue<TResult>(source, null);
+
                 throw new ArgumentException("The source query must be of type ObjectQuery or DbQuery.", "source");
+            }
 
             var methodExpr = selector.Body as MethodCallExpression;
             if (methodExpr == null || methodExpr.Arguments.Count == 0)
@@ -129,7 +147,13 @@ namespace EntityFramework.Extensions
 
             ObjectQuery sourceQuery = source.ToObjectQuery();
             if (sourceQuery == null)
+            {
+                // Early return for test scenarios, here so it only slows down the error path
+                if (source is IFutureTestQueryable<TEntity>)
+                    return new FutureValue<TEntity>(source, null);
+
                 throw new ArgumentException("The source query must be of type ObjectQuery or DbQuery.", "source");
+            }
 
             // make sure to only get the first value
             IQueryable<TEntity> firstQuery = source.Take(1);

--- a/Source/EntityFramework.Extended/Extensions/FutureExtensions.cs
+++ b/Source/EntityFramework.Extended/Extensions/FutureExtensions.cs
@@ -65,8 +65,6 @@ namespace EntityFramework.Extensions
 
             // create query from expression using internal ObjectQueryProvider
             ObjectQuery countQuery = sourceQuery.CreateQuery(expression, typeof(int));
-            if (countQuery == null)
-                throw new ArgumentException("The source query must be of type ObjectQuery or DbQuery.", "source");
 
             var futureContext = GetFutureContext(sourceQuery);
             var future = new FutureCount(countQuery, futureContext.ExecuteFutureQueries);
@@ -137,8 +135,6 @@ namespace EntityFramework.Extensions
             IQueryable<TEntity> firstQuery = source.Take(1);
 
             ObjectQuery<TEntity> objectQuery = firstQuery.ToObjectQuery();
-            if (objectQuery == null)
-                throw new ArgumentException("The source query must be of type ObjectQuery or DbQuery.", "source");
 
             var futureContext = GetFutureContext(sourceQuery);
             var future = new FutureValue<TEntity>(objectQuery, futureContext.ExecuteFutureQueries);

--- a/Source/EntityFramework.Extended/Future/FutureValue.cs
+++ b/Source/EntityFramework.Extended/Future/FutureValue.cs
@@ -10,7 +10,7 @@ namespace EntityFramework.Future
     /// <typeparam name="T">The type for the future query.</typeparam>
     /// <example>The following is an example of how to use FutureValue.
     /// <code><![CDATA[
-    /// var db = new TrackeContext;
+    /// var db = new TrackedContext();
     /// // build up queries
     /// var q1 = db.User.ByEmailAddress("one@test.com").FutureValue();
     /// var q2 = db.Task.Where(t => t.Summary == "Test").Future();
@@ -20,7 +20,7 @@ namespace EntityFramework.Future
     /// ]]>
     /// </code>
     /// </example>
-    [DebuggerDisplay("IsLoaded={IsLoaded}, Value={UnderlingValue}")]
+    [DebuggerDisplay("IsLoaded={IsLoaded}, Value={UnderlyingValue}")]
     public class FutureValue<T> : FutureQueryBase<T>
     {
         private bool _hasValue;

--- a/Source/EntityFramework.Extended/Future/IFutureTestQueryable.cs
+++ b/Source/EntityFramework.Extended/Future/IFutureTestQueryable.cs
@@ -1,0 +1,15 @@
+﻿using System.Linq;
+
+namespace EntityFramework.Future
+{
+    /// <summary>
+    /// Allows mocking and testing of the Future() ExtensionMethods.
+    /// </summary>
+    public interface IFutureTestQueryable : IQueryable { }
+
+    /// <summary>
+    /// Allows mocking and testing of the Future() ExtensionMethods.
+    /// </summary>
+    /// <typeparam name="T">Return type</typeparam>
+    public interface IFutureTestQueryable<T> : IQueryable<T>, IFutureTestQueryable { }
+}


### PR DESCRIPTION
I am maintaining code that does extensive mocking of the DbContext in order to write a unit test suite. This works fairly well, but I was having issues when ".Future()" became a part of some queries... since the underlying context is a mock, it returns List<T>s .AsQuerable() ... which Future hard-stops on.

With this update, Future() can accommodate this testing scenario by allowing tests to inherit from one of two IFutureTestQueryable interfaces.

While I will likely use this modified version going forward, I thought the changes might be more generally useful.

Please let me know if you have any questions or concerns.