### PR TITLE
Updated FutureRunner to Use Transaction

### DIFF
--- a/Source/EntityFramework.Extended/Future/FutureRunner.cs
+++ b/Source/EntityFramework.Extended/Future/FutureRunner.cs
@@ -14,6 +14,9 @@ namespace EntityFramework.Future
     /// </summary>
     public class FutureRunner : IFutureRunner
     {
+		  private const string _beginTransaction = "BEGIN TRANSACTION;";
+		  private const string _rollbackTransaction = "ROLLBACK TRANSACTION;";
+
         /// <summary>
         /// Executes the future queries.
         /// </summary>
@@ -71,6 +74,9 @@ namespace EntityFramework.Future
             var futureSql = new StringBuilder();
             int queryCount = 0;
 
+				if (command.Transaction == null)
+					 futureSql.AppendLine(_beginTransaction);
+
             foreach (IFutureQuery futureQuery in futureQueries)
             {
                 var plan = futureQuery.GetPlan(context);
@@ -111,7 +117,13 @@ namespace EntityFramework.Future
                 futureSql.AppendLine(";");
 
                 queryCount++;
-            } // foreach query
+				} // foreach query
+
+				if (command.Transaction == null)
+				{
+					 futureSql.AppendLine();
+				    futureSql.AppendLine(_rollbackTransaction);
+				}
 
             command.CommandText = futureSql.ToString();
             if (context.CommandTimeout.HasValue)


### PR DESCRIPTION
FutureRunner's command SQL is now inside a transaction.  This ensures that all data retrieved is “logically and physically consistent.”  See [MSDN documentation](https://msdn.microsoft.com/en-us/library/ms188929.aspx?f=255&MSPPError=-2147217396).