### PR TITLE
Fix to 172

### DIFF
--- a/Source/EntityFramework.Extended/Batch/SqlServerBatchRunner.cs
+++ b/Source/EntityFramework.Extended/Batch/SqlServerBatchRunner.cs
@@ -425,6 +425,9 @@ namespace EntityFramework.Batch
                 if (selector.Length > 4)
                     selector.Append((", "));
 
+                if (propertyMap.PropertyName == "GUID")
+                    propertyMap.PropertyName = "@GUID";
+
                 selector.Append(propertyMap.PropertyName);
             }
             selector.Append(")");


### PR DESCRIPTION
Possible fix/workaround for issue 172,  where batch update/deletes fail if the primary key contains a column called GUID.

